### PR TITLE
release references except the result V8Object

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.6.3"
+        classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -10,4 +10,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8Test.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8Test.kt
@@ -126,7 +126,10 @@ class K2V8Test {
             Gen.map(Gen.string(), Gen.string().filter { it.isNotEmpty() })
         ) { chars, longs, strings, enums, stringMap ->
             val supportedTypes = getSupportedTypes(chars, longs, strings, enums, stringMap)
+            val refCountStart = v8.objectReferenceCount
             with(k2V8.toV8(SupportedTypes.serializer(), supportedTypes)) {
+                // verify the k2V8.toV8 only increased the reference count by 1
+                (v8.objectReferenceCount - refCountStart) == 1L &&
                 getInteger("byte").toByte() == supportedTypes.byte &&
                     get("nullByte") == supportedTypes.nullByte &&
                     getInteger("nonNullByte").toByte() == supportedTypes.nonNullByte &&

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8Test.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8Test.kt
@@ -128,7 +128,7 @@ class K2V8Test {
             val supportedTypes = getSupportedTypes(chars, longs, strings, enums, stringMap)
             val refCountStart = v8.objectReferenceCount
             with(k2V8.toV8(SupportedTypes.serializer(), supportedTypes)) {
-                // verify the k2V8.toV8 only increased the reference count by 1
+                // verify the k2V8.toV8 only increased the reference count by 1 - the final result object
                 (v8.objectReferenceCount - refCountStart) == 1L &&
                 getInteger("byte").toByte() == supportedTypes.byte &&
                     get("nullByte") == supportedTypes.nullByte &&
@@ -301,7 +301,10 @@ class K2V8Test {
                 add("stringMap", stringStringV8Object)
                 add("enumMap", enumStringV8Array)
             }
+            val startCount = v8.objectReferenceCount
             with(k2V8.fromV8(SupportedTypes.serializer(), value)) {
+                // make sure the V8Object references all released.
+                v8.objectReferenceCount -  startCount == 0L &&
                 byte == supportedTypes.byte &&
                     nullByte == supportedTypes.nullByte &&
                     nonNullByte == supportedTypes.nonNullByte &&

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/V8ExtensionsTest.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/V8ExtensionsTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, inc.
+ *  All rights reserved.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.k2v8
+
+import com.eclipsesource.v8.V8
+import com.eclipsesource.v8.V8Object
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class V8ExtensionsTest {
+    private lateinit var v8: V8
+
+    @Before
+    fun setup() {
+        v8 = V8.createV8Runtime()
+    }
+
+    @After
+    fun cleanup() {
+        v8.close()
+    }
+
+    @Test
+    fun scopeTest() {
+        val foo = V8Object(v8)
+        assertEquals(1, v8.objectReferenceCount)
+        foo.close()
+        assertEquals(0, v8.objectReferenceCount)
+
+        // verify the object is released once scope is done
+        v8.scope {
+            val barObj = V8Object(v8)
+        }
+        assertEquals(0, v8.objectReferenceCount)
+    }
+
+    @Test
+    fun scopeWithResult() = v8.scope {
+        val foo = V8Object(v8)
+        assertEquals(1, v8.objectReferenceCount)
+        foo.close()
+        assertEquals(0, v8.objectReferenceCount)
+
+        // verify the object returned object still not release, others are.
+        val result = v8.scopeWithResult {
+            val barObj = V8Object(v8)
+            V8Object(v8)
+        }
+        assertEquals(1, v8.objectReferenceCount)
+    }
+}

--- a/k2v8/src/main/java/com/salesforce/k2v8/K2V8.kt
+++ b/k2v8/src/main/java/com/salesforce/k2v8/K2V8.kt
@@ -24,9 +24,7 @@ class K2V8(val configuration: Configuration, override val context: SerialModule 
      * Serializes a [T] value to a [V8Object] using the [serializer] provided.
      */
     fun <T> toV8(serializer: SerializationStrategy<T>, value: T) =
-        this.configuration.runtime.scopeWithResult {
-            convertToV8Object(value, serializer)
-        }
+        convertToV8Object(value, serializer)
 
     /**
      * Deserializes a [V8Object] value to a [T] using the [deserializer] provided.

--- a/k2v8/src/main/java/com/salesforce/k2v8/K2V8.kt
+++ b/k2v8/src/main/java/com/salesforce/k2v8/K2V8.kt
@@ -8,6 +8,7 @@
 package com.salesforce.k2v8
 
 import com.eclipsesource.v8.V8Object
+import com.eclipsesource.v8.utils.MemoryManager
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialFormat
 import kotlinx.serialization.SerializationStrategy
@@ -16,14 +17,16 @@ import kotlinx.serialization.modules.SerialModule
 /**
  * The main entry point for V8Object serialization.
  */
-class K2V8(val configuration: Configuration, override val context: SerialModule = DefaultModule) : SerialFormat {
+class K2V8(val configuration: Configuration, override val context: SerialModule = DefaultModule) :
+    SerialFormat {
 
     /**
      * Serializes a [T] value to a [V8Object] using the [serializer] provided.
      */
-    fun <T> toV8(serializer: SerializationStrategy<T>, value: T): V8Object {
-        return convertToV8Object(value, serializer)
-    }
+    fun <T> toV8(serializer: SerializationStrategy<T>, value: T) =
+        this.configuration.runtime.scopeWithResult {
+            convertToV8Object(value, serializer)
+        }
 
     /**
      * Deserializes a [V8Object] value to a [T] using the [deserializer] provided.

--- a/k2v8/src/main/java/com/salesforce/k2v8/V8Extensions.kt
+++ b/k2v8/src/main/java/com/salesforce/k2v8/V8Extensions.kt
@@ -10,16 +10,35 @@ package com.salesforce.k2v8
 import com.eclipsesource.v8.V8
 import com.eclipsesource.v8.V8Array
 import com.eclipsesource.v8.V8Object
+import com.eclipsesource.v8.V8Value
 import com.eclipsesource.v8.utils.MemoryManager
 import com.eclipsesource.v8.utils.V8ObjectUtils
 
 /**
  * Creates a scope around the function [body] releasing any objects after the [body] is invoked.
  */
-inline fun <T> V8.scope(body: () -> T): T {
+inline fun V8.scope(body: () -> Unit) {
     val scope = MemoryManager(this)
     try {
-        return body()
+        body()
+    } finally {
+        scope.release()
+    }
+}
+
+/**
+ * Creates a memory scope around the function [body].
+ * After the [body] is invoked, any V8Value objects created in the body will be released
+ * except the V8Value object is returned to caller for consumption.
+ */
+inline fun <T> V8.scopeWithResult(body: () -> T): T {
+    val scope = MemoryManager(this)
+    try {
+        return body().apply {
+            if (this is V8Value) {
+                scope.persist(this)
+            }
+        }
     } finally {
         scope.release()
     }

--- a/k2v8/src/main/java/com/salesforce/k2v8/V8ObjectEncoder.kt
+++ b/k2v8/src/main/java/com/salesforce/k2v8/V8ObjectEncoder.kt
@@ -210,8 +210,8 @@ class V8ObjectEncoder(
 
     override fun endStructure(descriptor: SerialDescriptor) {
 
-        // pop the current node off the stack
-        nodes.pop()
+        // pop the finished current node off the stack
+        val finishedNode = nodes.pop()
 
         // if the stack is empty we are done encoding
         if (nodes.empty()) {
@@ -219,6 +219,7 @@ class V8ObjectEncoder(
             // notify consumer
             rootNode?.v8Object?.apply(consumer)
         } else {
+            finishedNode.v8Object?.close()
             currentNode.reset()
         }
     }


### PR DESCRIPTION
toV8(serializer: Serialization...) converts kotlin object into V8Object. the root object could have children objects. We should close references for newly created children objects and only keep the reference for root V8Object. 

