### PR TITLE
Add test coverage for exception code path

### DIFF
--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8ExceptionTest.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8ExceptionTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, inc.
+ *  All rights reserved.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.k2v8
+
+import kotlinx.serialization.builtins.ListSerializer
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class K2V8ExceptionTest: K2V8TestBase() {
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+    }
+
+    @Test(expected = V8DecodingException::class)
+    fun enumListFromV8WithInvalidItem() = v8.scope {
+        val array = Enum.values()
+                .map { it.toString() }
+                .toMutableList()
+                .apply { add("VALUE_invalid") }
+                .toV8Array(v8)
+
+        val refCountStart = v8.objectReferenceCount
+        try {
+            k2V8.fromV8(ListSerializer(Enum.serializer()), array)
+        } catch ( ex: V8DecodingException) {
+            Assert.assertEquals(0, v8.objectReferenceCount - refCountStart)
+            throw ex
+        }
+    }
+}

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8ExceptionTest.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8ExceptionTest.kt
@@ -7,12 +7,18 @@
 
 package com.salesforce.k2v8
 
+import com.eclipsesource.v8.V8Object
+import com.eclipsesource.v8.V8ResultUndefined
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
-class K2V8ExceptionTest: K2V8TestBase() {
+class K2V8ExceptionTest : K2V8TestBase() {
+
+    @Serializable
+    class MapData(val data: Map<Int, String>)
 
     @Before
     override fun setUp() {
@@ -30,7 +36,58 @@ class K2V8ExceptionTest: K2V8TestBase() {
         val refCountStart = v8.objectReferenceCount
         try {
             k2V8.fromV8(ListSerializer(Enum.serializer()), array)
-        } catch ( ex: V8DecodingException) {
+        } catch (ex: V8DecodingException) {
+            Assert.assertEquals(0, v8.objectReferenceCount - refCountStart)
+            throw ex
+        }
+    }
+
+
+    // Verify decoding a class missing required field and no memory leak
+    // kotlinx.serialization.UnknownFieldException is thrown. It's internal, so use Exception
+    @Test(expected = Exception::class)
+    fun objFromV8MissingNoNullableField() = v8.scope {
+        val v8Object = V8Object(v8)
+
+        val refCountStart = v8.objectReferenceCount
+        try {
+            k2V8.fromV8(SealedClass.ClassOne.serializer(), v8Object)
+        } catch (ex: Exception) {
+            Assert.assertEquals(0, v8.objectReferenceCount - refCountStart)
+            throw ex
+        }
+    }
+
+    /**
+     * Give an integration to an object property which suppose to be object and
+     * verify decoding fail and no memory leak
+     */
+    @Test(expected = V8ResultUndefined::class)
+    fun objectFromV8WrongTypeOfField() = v8.scope {
+        val v8Object = V8Object(v8).apply {
+            add("nestedObject", 123)
+            add("100", "100")
+        }
+
+        val refCountStart = v8.objectReferenceCount
+        try {
+            k2V8.fromV8(DoubleNestedObject.serializer(), v8Object)
+        } catch (ex: V8ResultUndefined) {
+            Assert.assertEquals(0, v8.objectReferenceCount - refCountStart)
+            throw ex
+        }
+    }
+
+    /**
+     * Currently toV8 doesn't support map<Int, *>. so exception raised.
+     * this test verify no memory leak even with exception
+     */
+    @Test(expected = V8EncodingException::class)
+    fun objectToV8() = v8.scope {
+        val refCountStart = v8.objectReferenceCount
+        try {
+            k2V8.toV8(MapData.serializer(), MapData(mapOf(100 to "100")))
+        } catch (ex: V8EncodingException) {
             Assert.assertEquals(0, v8.objectReferenceCount - refCountStart)
             throw ex
         }

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8TestBase.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/K2V8TestBase.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, inc.
+ *  All rights reserved.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.k2v8
+
+import com.eclipsesource.v8.V8
+import kotlinx.serialization.Serializable
+
+open class K2V8TestBase {
+    @Serializable
+    @Suppress("unused")
+    enum class Enum {
+        VALUE_1,
+        VALUE_2,
+        VALUE_3
+    }
+
+    @Serializable
+    sealed class SealedClass {
+
+        @Serializable
+        data class ClassOne(val someString: String) : SealedClass()
+
+        @Serializable
+        data class ClassTwo(val someInt: Int) : SealedClass()
+    }
+
+    @Serializable
+    data class SupportedTypes(
+            val byte: Byte,
+            val nullByte: Byte?,
+            val nonNullByte: Byte?,
+            val short: Short,
+            val nullShort: Short?,
+            val nonNullShort: Short?,
+            val char: Char,
+            val nullChar: Char?,
+            val nonNullChar: Char?,
+            val int: Int,
+            val nullInt: Int?,
+            val nonNullInt: Int?,
+            val long: Long,
+            val nullLong: Long?,
+            val nonNullLong: Long?,
+            val double: Double,
+            val nullDouble: Double?,
+            val nonNullDouble: Double?,
+            val float: Float,
+            val nullFloat: Float?,
+            val nonNullFloat: Float?,
+            val string: String,
+            val nullString: String?,
+            val nonNullString: String?,
+            val boolean: Boolean,
+            val nullBoolean: Boolean?,
+            val nonNullBoolean: Boolean?,
+            val enum: Enum,
+            val nullEnum: Enum?,
+            val unit: Unit,
+            val nestedObject: NestedObject,
+            val nullNestedObject: NestedObject?,
+            val nonNullNestedObject: NestedObject?,
+            val doubleNestedObject: DoubleNestedObject,
+            val byteList: List<Byte>,
+            val shortList: List<Short>,
+            val charList: List<Char>,
+            val intList: List<Int>,
+            val longList: List<Long>,
+            val floatList: List<Float>,
+            val doubleList: List<Double>,
+            val stringList: List<String>,
+            val booleanList: List<Boolean>,
+            val enumList: List<Enum>,
+            val nestedObjectList: List<NestedObject>,
+            val stringMap: Map<String, String>,
+            val enumMap: Map<Enum, String>
+    )
+
+    @Serializable
+    data class NestedObject(
+            val value: String
+    )
+
+    @Serializable
+    data class DoubleNestedObject(
+            val nestedObject: NestedObject
+    )
+
+    @Serializable
+    data class NullableNestedObject(
+            val value: String,
+            val nestedMap: Map<String, String>? = null,
+            val nestedList: List<NestedObject>? = null
+    )
+
+    protected lateinit var v8: V8
+    protected lateinit var k2V8: K2V8
+
+    open fun setUp() {
+        v8 = V8.createV8Runtime()
+        k2V8 = K2V8(Configuration(v8))
+    }
+}

--- a/k2v8/src/androidTest/java/com/salesforce/k2v8/V8ExtensionsTest.kt
+++ b/k2v8/src/androidTest/java/com/salesforce/k2v8/V8ExtensionsTest.kt
@@ -36,7 +36,7 @@ class V8ExtensionsTest {
 
         // verify the object is released once scope is done
         v8.scope {
-            val barObj = V8Object(v8)
+            V8Object(v8)
         }
         assertEquals(0, v8.objectReferenceCount)
     }

--- a/k2v8/src/main/java/com/salesforce/k2v8/V8ObjectEncoder.kt
+++ b/k2v8/src/main/java/com/salesforce/k2v8/V8ObjectEncoder.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
+import java.lang.Exception
 import java.util.Stack
 
 internal fun <T> K2V8.convertToV8Object(value: T, serializer: SerializationStrategy<T>): V8Object {
@@ -181,7 +182,12 @@ class V8ObjectEncoder(
         value: T
     ) {
         currentNode.encodeElementIndex(descriptor, index)
-        encodeSerializableValue(serializer, value)
+        try {
+            encodeSerializableValue(serializer, value)
+        } catch (ex: Exception) {
+            closeAllNodes()
+            throw ex
+        }
     }
 
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
@@ -295,6 +301,12 @@ class V8ObjectEncoder(
                     }
                 }
             }
+        }
+    }
+
+    private fun closeAllNodes() {
+        nodes.forEach {
+            it?.v8Object?.close()
         }
     }
 }


### PR DESCRIPTION
- polish the happy path for test that there's no j2v8 memory leaked 
- add test coverage for exception code path and no j2v8 memory leaked
-- decode an invalid string from v8 as enum 
-- decode v8 object into kotlin object with mandatory field missing
-- encode an object with a map<Int,*>, raise exception. 